### PR TITLE
Breaking API revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ pub fn main() !void {
     try glfw.init();
     defer glfw.terminate();
 
+    const window = try glfw.createWindow(600, 600, "zig-gamedev: minimal_glfw_gl", null);
+    defer glfw.destroyWindow(window);
+
+    // or, using the equivilent, encapsulated, "objecty" API:
     const window = try glfw.Window.create(600, 600, "zig-gamedev: minimal_glfw_gl", null);
     defer window.destroy();
 


### PR DESCRIPTION
- Support flat vanilla API aswell as encapulated, objecty API
- setWindowHint, setInputMode & setWindowAttribute are typed by default with *Untyped variants (literal, comptime-known, args is the common case).
- Fix some incorrect types
- Distinguish Bool type
- More error handling for some procs where it is helpful.
- Add some missing bindings
  - Closes #1
  - Closes #3
  - Closes #4