### PR TITLE
Add headers to artifact include tree

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -54,6 +54,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     b.installArtifact(glfw);
+    b.installHeadersDirectory(b.path("libs/glfw/include"), "", .{});
 
     glfw.addIncludePath(b.path("libs/glfw/include"));
     glfw.linkLibC();

--- a/build.zig
+++ b/build.zig
@@ -54,7 +54,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     b.installArtifact(glfw);
-    b.installHeadersDirectory(b.path("libs/glfw/include"), "", .{});
+    glfw.installHeadersDirectory(b.path("libs/glfw/include"), "", .{});
 
     glfw.addIncludePath(b.path("libs/glfw/include"));
     glfw.linkLibC();


### PR DESCRIPTION
This should enable other C dependencies to properly link against the library by doing something like the following:

``` zig
const other_lib = b.addStaticLibrary(.{...});
other_lib.addCSourceFile(.{...});

other_lib.linkLibrary(b.dependency("zglfw", .{}));
// Or…
other_lib.addIncludePath(b.dependency("zglfw", .{}).getEmittedIncludeTree());
```

(Caveat: novice Zig user. Please feel free to correct any misunderstandings you see.)