### PR TITLE
Make `convertError()` public

### DIFF
--- a/src/zglfw.zig
+++ b/src/zglfw.zig
@@ -114,7 +114,7 @@ pub const Error = error{
     Unknown,
 };
 
-fn convertError(e: ErrorCode) Error!void {
+pub fn convertError(e: ErrorCode) Error!void {
     return switch (e) {
         0 => {},
         0x00010001 => Error.NotInitialized,


### PR DESCRIPTION
Hi!
While using `setErrorCallback`, I've seen that the first parameter is the `ErrorCode`, which I wanted to convert to an `Error`. However, the `convertError` function is private so I would have to reimplement it in my code, but I don't want to do that.
Could we make `convertError` public for that use case?