### PR TITLE
added recommended comment to fingerprint line from default `build.zig.zon` file in Zig `0.14.0`

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zglfw,
-    .fingerprint = 0x6fbada33344305ce,
+    .fingerprint = 0x6fbada33344305ce, // Changing this has security and trust implications.
     .version = "0.10.0-dev",
     .paths = .{
         "build.zig",


### PR DESCRIPTION
Currently, the fingerprint line on zglfw's `build.zig.zon` line has no mention that changing the fingerprint has security and trust implications!

The default `build.zig.zon` file (generated in Zig `0.14.0` via the command `zig init`) contains the following (lines 15 - 27):

```zig
// Together with name, this represents a globally unique package
// identifier. This field is generated by the Zig toolchain when the
// package is first created, and then *never changes*. This allows
// unambiguous detection of one package being an updated version of
// another.
//
// When forking a Zig project, this id should be regenerated (delete the
// field and run `zig build`) if the upstream project is still maintained.
// Otherwise, the fork is *hostile*, attempting to take control over the
// original project's identity. Thus it is recommended to leave the comment
// on the following line intact, so that it shows up in code reviews that
// modify the field.
.fingerprint = 0xe1e07974043f7a7, // Changing this has security and trust implications.
```

Note in particular this line above:

> Thus it is recommended to leave the comment on the following line intact, so that it shows up in code reviews that modify the field.

I.e, the default `build.zig.zon` file recommends that the fingerprint is followed by the comment `// Changing this has security and trust implications.`

This PR simply follows the recommendation by adding this comment to zglfw's `build.zig.zon` file.