### PR TITLE
Remove duplicate C source file.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -137,7 +137,6 @@ pub fn build(b: *std.Build) void {
                     src_dir ++ "posix_time.c",
                     src_dir ++ "posix_thread.c",
                     src_dir ++ "posix_module.c",
-                    src_dir ++ "egl_context.c",
                 },
                 .flags = &.{},
             });


### PR DESCRIPTION
`egl_context.c` was originally duplicated in the linux section of the glfw build script, which was causing errors on my system.