### PR TITLE
Add missing Window bindings

### DIFF
--- a/src/zglfw.zig
+++ b/src/zglfw.zig
@@ -71,8 +71,9 @@ extern fn glfwWaitEvents() void;
 pub const waitEventsTimeout = glfwWaitEventsTimeout;
 extern fn glfwWaitEventsTimeout(timeout: f64) void;
 
-// FIXME: missing binding
-// glfwPostEmptyEvent
+/// `pub fn postEmptyEvent() void`
+pub const postEmptyEvent = glfwPostEmptyEvent;
+extern fn glfwPostEmptyEvent() void;
 
 pub fn isVulkanSupported() bool {
     return glfwVulkanSupported() == TRUE;


### PR DESCRIPTION
Adds missing bindings for the glfw functions:
- `glfwSetWindowAspectRatio`
- `glfwGetWindowFrameSize`
- `glfwGetWindowOpacity`
- `glfwSetWindowOpacity`
- `glfwIconifyWindow`
- `glfwRestoreWindow`
- `glfwMaximizeWindow`
- `glfwHideWIndow`
- `glfwRequestWindowAttention`
- `glfwPostEmptyEvent`

All functions except for `postEmptyEvent` have been aliased as methods to the `Window` struct to support the "objecty" API.