### PR TITLE
Add bindings for glfw Vulkan functions

### DIFF
--- a/src/zglfw.zig
+++ b/src/zglfw.zig
@@ -90,6 +90,55 @@ pub fn getRequiredInstanceExtensions() Error![][*:0]const u8 {
 }
 extern fn glfwGetRequiredInstanceExtensions(count: *u32) ?*?[*:0]const u8;
 
+pub const VulkanFn = *const fn () callconv(.c) void;
+pub const VkInstance = ?*const anyopaque;
+pub const VkPhysicalDevice = ?*const anyopaque;
+pub const VkAllocationCallbacks = anyopaque;
+pub const VkSurfaceKHR = anyopaque;
+
+pub fn getInstanceProcAddress(instance: VkInstance, procname: [*:0]const u8) Error!VulkanFn {
+    if (glfwGetInstanceProcAddress(instance, procname)) |address| {
+        return address;
+    }
+    try maybeError();
+    return error.APIUnavailable;
+}
+extern fn glfwGetInstanceProcAddress(instance: VkInstance, procname: [*:0]const u8) ?VulkanFn;
+
+pub fn getPhysicalDevicePresentationSupport(
+    instance: VkInstance,
+    device: VkPhysicalDevice,
+    queuefamily: u32,
+) Error!bool {
+    const result = glfwGetPhysicalDevicePresentationSupport(instance, device, queuefamily) == TRUE;
+    try maybeError();
+    return result;
+}
+extern fn glfwGetPhysicalDevicePresentationSupport(
+    instance: VkInstance,
+    device: VkPhysicalDevice,
+    queuefamily: u32,
+) Bool;
+
+pub fn createWindowSurface(
+    instance: VkInstance,
+    window: *Window,
+    allocator: ?*const VkAllocationCallbacks,
+    surface: *VkSurfaceKHR,
+) Error!void {
+    if (glfwCreateWindowSurface(instance, window, allocator, surface) == 0) {
+        return;
+    }
+    try maybeError();
+    return Error.APIUnavailable;
+}
+extern fn glfwCreateWindowSurface(
+    instance: VkInstance,
+    window: *Window,
+    allocator: ?*const VkAllocationCallbacks,
+    surface: *VkSurfaceKHR,
+) c_int;
+
 /// `pub fn getTime() f64`
 pub const getTime = glfwGetTime;
 extern fn glfwGetTime() f64;


### PR DESCRIPTION
Added bindings for remaining unimplemented Vulkan functions:
- `glfwGetInstanceProcAddress`
- `glfwGetPhysicalDevicePresentationSupport`
- `glfwCreateWindowSurface`

Library user will need to supply their own instance, device, surface, and allocation callback pointers. The types for Vulkan objects `VkInstance` and `VkPhysicalDevice` are just aliased to `?*const anyopaque`, and the types for Vulkan structs `VkAllocationCallbacks` and `VkSurfaceKHR` were aliased to `anyopaque`. The main intent of these aliases is to provide clarity on the expected Vulkan types and ensure the bindings function signatures are mostly aligned with the glfw API (https://www.glfw.org/docs/3.3/group__vulkan.html).

I've tested `getInstanceProcAddress` to confirm that it retrieves function pointers correctly, and that those function pointers can be called correctly when cast to the command signature, however I didn't go all the way to creating a new Vulkan instance because I don't have the SDK set up on my current computer. 

Fixes #18 