### PR TITLE
Add support for importing correct Vulkan types

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pub fn main() !void {
     const window = try glfw.createWindow(600, 600, "zig-gamedev: minimal_glfw_gl", null);
     defer glfw.destroyWindow(window);
 
-    // or, using the equivilent, encapsulated, "objecty" API:
+    // or, using the equivalent, encapsulated, "objecty" API:
     const window = try glfw.Window.create(600, 600, "zig-gamedev: minimal_glfw_gl", null);
     defer window.destroy();
 
@@ -39,10 +39,47 @@ pub fn main() !void {
         glfw.pollEvents();
 
         // render your things here
-        
+
         window.swapBuffers();
     }
 }
 ```
 
 See [zig-gamedev samples](https://github.com/zig-gamedev/zig-gamedev/tree/main/samples) for more complete usage examples.
+
+
+## Usage with Vulkan
+
+To match types from `zglfw` functions and Vulkan library `import_vulkan` option may be used. When using this option `vulkan` import must be provided to the root module.
+
+Example `build.zig` with [`vulkan-zig`](https://github.com/Snektron/vulkan-zig):
+
+```zig
+const vulkan_headers = b.dependency("vulkan_headers");
+const vulkan = b.dependency("vulkan_zig", .{
+    .registry = vulkan_headers.path("registry/vk.xml"),
+}).module("vulkan-zig");
+
+
+const zglfw = b.dependency("zglfw", .{ .import_vulkan = true });
+
+const zglfw_mod = zglfw.module("root");
+zglfw_mod.addImport("vulkan", vulkan);
+
+const exe = b.addExecutable(.{
+    .name = "vk_setup",
+    .root_module = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "zglfw", .module = zglfw_mod },
+            .{ .name = "vulkan", .module = vulkan },
+        },
+    }),
+});
+
+exe.root_module.addImport("vulkan", vulkan);
+exe.root_module.linkLibrary(zglfw.artifact("glfw"));
+
+```

--- a/build.zig
+++ b/build.zig
@@ -20,6 +20,11 @@ pub fn build(b: *std.Build) void {
             "wayland",
             "Whether to build with Wayland support (default: true)",
         ) orelse true,
+        .enable_vulkan_import = b.option(
+            bool,
+            "import_vulkan",
+            "Whether to build with external Vulkan dependency (default: false)",
+        ) orelse false,
     };
 
     const options_step = b.addOptions();

--- a/src/zglfw.zig
+++ b/src/zglfw.zig
@@ -91,23 +91,23 @@ pub fn getRequiredInstanceExtensions() Error![][*:0]const u8 {
 extern fn glfwGetRequiredInstanceExtensions(count: *u32) ?*?[*:0]const u8;
 
 pub const VulkanFn = *const fn () callconv(.c) void;
-pub const VkInstance = ?*const anyopaque;
-pub const VkPhysicalDevice = ?*const anyopaque;
-pub const VkAllocationCallbacks = anyopaque;
-pub const VkSurfaceKHR = anyopaque;
 
-pub fn getInstanceProcAddress(instance: VkInstance, procname: [*:0]const u8) Error!VulkanFn {
-    if (glfwGetInstanceProcAddress(instance, procname)) |address| {
-        return address;
-    }
-    try maybeError();
-    return error.APIUnavailable;
-}
-extern fn glfwGetInstanceProcAddress(instance: VkInstance, procname: [*:0]const u8) ?VulkanFn;
+const vk = if (options.enable_vulkan_import)
+    @import("vulkan")
+else
+    struct {
+        pub const Instance = ?*const anyopaque;
+        pub const PhysicalDevice = ?*const anyopaque;
+        pub const AllocationCallbacks = anyopaque;
+        pub const SurfaceKHR = anyopaque;
+    };
+
+pub const getInstanceProcAddress = glfwGetInstanceProcAddress;
+extern fn glfwGetInstanceProcAddress(instance: vk.Instance, procname: [*:0]const u8) ?VulkanFn;
 
 pub fn getPhysicalDevicePresentationSupport(
-    instance: VkInstance,
-    device: VkPhysicalDevice,
+    instance: vk.Instance,
+    device: vk.PhysicalDevice,
     queuefamily: u32,
 ) Error!bool {
     const result = glfwGetPhysicalDevicePresentationSupport(instance, device, queuefamily) == TRUE;
@@ -115,16 +115,16 @@ pub fn getPhysicalDevicePresentationSupport(
     return result;
 }
 extern fn glfwGetPhysicalDevicePresentationSupport(
-    instance: VkInstance,
-    device: VkPhysicalDevice,
+    instance: vk.Instance,
+    device: vk.PhysicalDevice,
     queuefamily: u32,
 ) Bool;
 
 pub fn createWindowSurface(
-    instance: VkInstance,
+    instance: vk.Instance,
     window: *Window,
-    allocator: ?*const VkAllocationCallbacks,
-    surface: *VkSurfaceKHR,
+    allocator: ?*const vk.AllocationCallbacks,
+    surface: *vk.SurfaceKHR,
 ) Error!void {
     if (glfwCreateWindowSurface(instance, window, allocator, surface) == 0) {
         return;
@@ -133,10 +133,10 @@ pub fn createWindowSurface(
     return Error.APIUnavailable;
 }
 extern fn glfwCreateWindowSurface(
-    instance: VkInstance,
+    instance: vk.Instance,
     window: *Window,
-    allocator: ?*const VkAllocationCallbacks,
-    surface: *VkSurfaceKHR,
+    allocator: ?*const vk.AllocationCallbacks,
+    surface: *vk.SurfaceKHR,
 ) c_int;
 
 /// `pub fn getTime() f64`


### PR DESCRIPTION
This PR adds the ability for users to add their own module, which will be used to determine correct types for Vulkan implementation.

Most popular Vulkan implementation in Zig is [vulkan-zig](https://github.com/Snektron/vulkan-zig) (made by Zig maintainer), and it uses fancy `enum { .null_handle = 0, _ }` types to add type checking to Vulkan opaque handles. This creates some type mismatches with zglfw. 


First, thank you, @Fincap, for providing initial implementation. I had to change `getInstanceProcAddress` to not be wrapped in zglfw error handling. This function will be passed to the other C libraries (i.e. VulkanMemoryAllocator) , and should not return Zig error union.  (Also, this happens with OpenGL #33).

There are few additional issues here. `VkAllocationCallbacks` isn't opaque. It has defined format, which users can supply.

`createWindowSurface` returns `Error.APIUnavailable` for any result besides `VK_SUCCESS`. That isn't true if for example `VK_ERROR_OUT_OF_DEVICE_MEMORY` is returned [(docs with possible results)](https://registry.khronos.org/vulkan/specs/latest/man/html/vkCreateWin32SurfaceKHR.html).


I have tested this in Vulkan app with vulkan-zig and OpenGL app to see that everything still works.




